### PR TITLE
feat: show predicted scoreline in voter panel for knockout matches

### DIFF
--- a/netlify/functions/activateWcMatch.js
+++ b/netlify/functions/activateWcMatch.js
@@ -139,9 +139,12 @@ export const handler = async (event) => {
       is_banker_match,
       trivia_question,
       trivia_options,
+      is_knockout,
     } = JSON.parse(event.body);
 
     const bankerMatch = is_banker_match === true;
+    // Default true — all new matches are knockout. Admin can uncheck for any non-knockout match.
+    const isKnockout = is_knockout !== false;
 
     // Optional bonus trivia — only stored when there's a question and ≥2 options.
     let triviaQuestion = null;
@@ -202,8 +205,8 @@ export const handler = async (event) => {
     }
 
     const [saved] = await sql`
-      INSERT INTO wc_matches (fixture_id, home_team, away_team, home_code, away_code, home_flag, away_flag, kickoff_time, status, activated_at, is_banker_match, trivia_question, trivia_options)
-      VALUES (${fixture_id}, ${home_team}, ${away_team}, ${home_code}, ${away_code}, ${storedHomeFlag}, ${storedAwayFlag}, ${kickoff_time}, 'active', NOW(), ${bankerMatch}, ${triviaQuestion}, ${triviaOptions})
+      INSERT INTO wc_matches (fixture_id, home_team, away_team, home_code, away_code, home_flag, away_flag, kickoff_time, status, activated_at, is_banker_match, trivia_question, trivia_options, is_knockout)
+      VALUES (${fixture_id}, ${home_team}, ${away_team}, ${home_code}, ${away_code}, ${storedHomeFlag}, ${storedAwayFlag}, ${kickoff_time}, 'active', NOW(), ${bankerMatch}, ${triviaQuestion}, ${triviaOptions}, ${isKnockout})
       ON CONFLICT (fixture_id)
       DO UPDATE SET
         status = 'active',
@@ -212,7 +215,8 @@ export const handler = async (event) => {
         activated_at = NOW(),
         is_banker_match = ${bankerMatch},
         trivia_question = ${triviaQuestion},
-        trivia_options = ${triviaOptions}
+        trivia_options = ${triviaOptions},
+        is_knockout = ${isKnockout}
       RETURNING id, cronjob_id
     `;
 

--- a/netlify/functions/fetchWcResult.js
+++ b/netlify/functions/fetchWcResult.js
@@ -188,14 +188,34 @@ export const handler = async (event) => {
       WHERE id = ${match_id}
     `;
 
-    await sql`
-      UPDATE wc_predictions
-      SET points = CASE
-        WHEN prediction = ${result} THEN (CASE WHEN is_banker THEN 2 ELSE 1 END)
-        ELSE (CASE WHEN is_banker THEN -1 ELSE 0 END)
-      END
-      WHERE match_id = ${match_id}
-    `;
+    if (match.is_knockout) {
+      // Knockout: winner points (banker doubles) + flat score bonus (no banker effect)
+      await sql`
+        UPDATE wc_predictions
+        SET points = CASE
+          WHEN predicted_winner = ${result} THEN (CASE WHEN is_banker THEN 2 ELSE 1 END)
+          ELSE (CASE WHEN is_banker THEN -1 ELSE 0 END)
+        END
+        WHERE match_id = ${match_id}
+      `;
+      await sql`
+        UPDATE wc_predictions
+        SET score_points = CASE
+          WHEN predicted_home_goals = ${homeGoals} AND predicted_away_goals = ${awayGoals} THEN 5
+          ELSE 0
+        END
+        WHERE match_id = ${match_id}
+      `;
+    } else {
+      await sql`
+        UPDATE wc_predictions
+        SET points = CASE
+          WHEN prediction = ${result} THEN (CASE WHEN is_banker THEN 2 ELSE 1 END)
+          ELSE (CASE WHEN is_banker THEN -1 ELSE 0 END)
+        END
+        WHERE match_id = ${match_id}
+      `;
+    }
 
     // Result is in — cancel the pending auto-fetch cron so it doesn't fire again.
     await cancelJob(match.cronjob_id);

--- a/netlify/functions/fetchWcResult.js
+++ b/netlify/functions/fetchWcResult.js
@@ -74,7 +74,17 @@ async function fetchFromApiFootball(match) {
     return { notFinished: true, status };
   }
 
-  return { homeGoals, awayGoals, source: 'api-football' };
+  // For PEN matches, determine who won the shootout
+  let penaltyWinner = null;
+  if (status === 'PEN' && homeGoals === awayGoals) {
+    const penHome = fixture.score?.penalty?.home;
+    const penAway = fixture.score?.penalty?.away;
+    if (penHome != null && penAway != null) {
+      penaltyWinner = penHome > penAway ? 'home' : 'away';
+    }
+  }
+
+  return { homeGoals, awayGoals, penaltyWinner, source: 'api-football' };
 }
 
 // ── football-data.org fallback ────────────────────────────────────────────────
@@ -96,7 +106,17 @@ async function fetchFromFootballData(match) {
     return { notFinished: true, status };
   }
 
-  return { homeGoals, awayGoals, source: 'football-data' };
+  // For penalty-decided matches, determine who won the shootout
+  let penaltyWinner = null;
+  if (homeGoals === awayGoals) {
+    const penHome = matchData.score?.penalties?.home;
+    const penAway = matchData.score?.penalties?.away;
+    if (penHome != null && penAway != null) {
+      penaltyWinner = penHome > penAway ? 'home' : 'away';
+    }
+  }
+
+  return { homeGoals, awayGoals, penaltyWinner, source: 'football-data' };
 }
 
 // ── Handler ───────────────────────────────────────────────────────────────────
@@ -176,6 +196,7 @@ export const handler = async (event) => {
     let result;
     if (homeGoals > awayGoals) result = 'home';
     else if (awayGoals > homeGoals) result = 'away';
+    else if (match.is_knockout && scoreData.penaltyWinner) result = scoreData.penaltyWinner;
     else result = 'draw';
 
     await sql`

--- a/netlify/functions/fetchWcResult.js
+++ b/netlify/functions/fetchWcResult.js
@@ -215,7 +215,7 @@ export const handler = async (event) => {
         UPDATE wc_predictions
         SET points = CASE
           WHEN predicted_winner = ${result} THEN (CASE WHEN is_banker THEN 2 ELSE 1 END)
-          ELSE (CASE WHEN is_banker THEN -1 ELSE 0 END)
+          ELSE (CASE WHEN is_banker THEN -2 ELSE 0 END)
         END
         WHERE match_id = ${match_id}
       `;

--- a/netlify/functions/getActiveWcMatch.js
+++ b/netlify/functions/getActiveWcMatch.js
@@ -142,9 +142,13 @@ export const handler = async (event) => {
         wp.player_id,
         wp.prediction,
         wp.points,
+        wp.score_points,
         wp.is_banker,
         wp.trivia_guess,
         wp.trivia_points,
+        wp.predicted_home_goals,
+        wp.predicted_away_goals,
+        wp.predicted_winner,
         p.name AS player_name,
         p.photo AS player_photo
       FROM wc_predictions wp

--- a/netlify/functions/getWcLeaderboard.js
+++ b/netlify/functions/getWcLeaderboard.js
@@ -19,7 +19,7 @@ export const handler = async (event) => {
         p.id AS player_id,
         p.name AS player_name,
         p.photo AS player_photo,
-        COALESCE(SUM(wp.points), 0) + COALESCE(SUM(wp.trivia_points), 0) AS total_points,
+        COALESCE(SUM(wp.points), 0) + COALESCE(SUM(wp.score_points), 0) + COALESCE(SUM(wp.trivia_points), 0) AS total_points,
         COUNT(wp.id) AS predictions_made,
         COUNT(CASE WHEN wp.points > 0 THEN 1 END) AS correct_predictions
       FROM players p

--- a/netlify/functions/setWcResultManual.js
+++ b/netlify/functions/setWcResultManual.js
@@ -80,14 +80,34 @@ export const handler = async (event) => {
       WHERE id = ${match_id}
     `;
 
-    await sql`
-      UPDATE wc_predictions
-      SET points = CASE
-        WHEN prediction = ${result} THEN (CASE WHEN is_banker THEN 2 ELSE 1 END)
-        ELSE (CASE WHEN is_banker THEN -1 ELSE 0 END)
-      END
-      WHERE match_id = ${match_id}
-    `;
+    if (match.is_knockout) {
+      // Knockout: winner points (banker doubles) + flat score bonus (no banker effect)
+      await sql`
+        UPDATE wc_predictions
+        SET points = CASE
+          WHEN predicted_winner = ${result} THEN (CASE WHEN is_banker THEN 2 ELSE 1 END)
+          ELSE (CASE WHEN is_banker THEN -1 ELSE 0 END)
+        END
+        WHERE match_id = ${match_id}
+      `;
+      await sql`
+        UPDATE wc_predictions
+        SET score_points = CASE
+          WHEN predicted_home_goals = ${hg} AND predicted_away_goals = ${ag} THEN 5
+          ELSE 0
+        END
+        WHERE match_id = ${match_id}
+      `;
+    } else {
+      await sql`
+        UPDATE wc_predictions
+        SET points = CASE
+          WHEN prediction = ${result} THEN (CASE WHEN is_banker THEN 2 ELSE 1 END)
+          ELSE (CASE WHEN is_banker THEN -1 ELSE 0 END)
+        END
+        WHERE match_id = ${match_id}
+      `;
+    }
 
     // Cancel the pending auto-fetch cron job now that the result is set manually.
     await cancelJob(match.cronjob_id);

--- a/netlify/functions/setWcResultManual.js
+++ b/netlify/functions/setWcResultManual.js
@@ -97,7 +97,7 @@ export const handler = async (event) => {
         UPDATE wc_predictions
         SET points = CASE
           WHEN predicted_winner = ${result} THEN (CASE WHEN is_banker THEN 2 ELSE 1 END)
-          ELSE (CASE WHEN is_banker THEN -1 ELSE 0 END)
+          ELSE (CASE WHEN is_banker THEN -2 ELSE 0 END)
         END
         WHERE match_id = ${match_id}
       `;

--- a/netlify/functions/setWcResultManual.js
+++ b/netlify/functions/setWcResultManual.js
@@ -23,7 +23,7 @@ export const handler = async (event) => {
   }
 
   try {
-    const { match_id, home_goals, away_goals, override } = JSON.parse(event.body);
+    const { match_id, home_goals, away_goals, penalty_winner, override } = JSON.parse(event.body);
 
     if (!match_id || home_goals === undefined || away_goals === undefined) {
       return {
@@ -68,7 +68,18 @@ export const handler = async (event) => {
     let result;
     if (hg > ag) result = 'home';
     else if (ag > hg) result = 'away';
-    else result = 'draw';
+    else if (match.is_knockout) {
+      if (penalty_winner !== 'home' && penalty_winner !== 'away') {
+        return {
+          statusCode: 400,
+          headers: corsHeaders,
+          body: JSON.stringify({ error: 'Knockout match with equal score requires penalty_winner (home|away)' }),
+        };
+      }
+      result = penalty_winner;
+    } else {
+      result = 'draw';
+    }
 
     await sql`
       UPDATE wc_matches

--- a/netlify/functions/submitPrediction.js
+++ b/netlify/functions/submitPrediction.js
@@ -33,7 +33,7 @@ export const handler = async (event) => {
 
   try {
     const body = JSON.parse(event.body);
-    const { match_id, player_id, prediction } = body;
+    const { match_id, player_id } = body;
     const is_banker = body.is_banker === true;
     // Optional trivia guess — a 0-based option index, or null if unanswered.
     let triviaGuess = null;
@@ -42,19 +42,11 @@ export const handler = async (event) => {
       if (!isNaN(g) && g >= 0) triviaGuess = g;
     }
 
-    if (!match_id || !player_id || !prediction) {
+    if (!match_id || !player_id) {
       return {
         statusCode: 400,
         headers: corsHeaders,
         body: JSON.stringify({ error: "Missing required fields" }),
-      };
-    }
-
-    if (!["home", "draw", "away"].includes(prediction)) {
-      return {
-        statusCode: 400,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: "Invalid prediction value" }),
       };
     }
 
@@ -155,15 +147,76 @@ export const handler = async (event) => {
       }
     }
 
-    // Upsert — predictions can be changed until the match locks (kickoff guard
-    // above). Re-submitting overwrites the pick, banker flag and trivia guess.
-    // trivia_points is left untouched (awarded later by setWcTriviaResult).
-    await sql`
-      INSERT INTO wc_predictions (match_id, player_id, prediction, is_banker, trivia_guess)
-      VALUES (${match_id}, ${player_id}, ${prediction}, ${is_banker}, ${validTriviaGuess})
-      ON CONFLICT (match_id, player_id)
-      DO UPDATE SET prediction = ${prediction}, is_banker = ${is_banker}, trivia_guess = ${validTriviaGuess}
-    `;
+    if (match.is_knockout) {
+      // Knockout round: scoreline + winner prediction
+      const predictedHomeGoals = parseInt(body.predicted_home_goals, 10);
+      const predictedAwayGoals = parseInt(body.predicted_away_goals, 10);
+      const predictedWinner = body.predicted_winner;
+
+      if (isNaN(predictedHomeGoals) || isNaN(predictedAwayGoals) || predictedHomeGoals < 0 || predictedAwayGoals < 0) {
+        return {
+          statusCode: 400,
+          headers: corsHeaders,
+          body: JSON.stringify({ error: 'predicted_home_goals and predicted_away_goals must be non-negative integers' }),
+        };
+      }
+      if (!['home', 'away'].includes(predictedWinner)) {
+        return {
+          statusCode: 400,
+          headers: corsHeaders,
+          body: JSON.stringify({ error: 'predicted_winner must be home or away' }),
+        };
+      }
+      // Server-side guard: non-equal score must have winner match the leading team
+      if (predictedHomeGoals !== predictedAwayGoals) {
+        const expectedWinner = predictedHomeGoals > predictedAwayGoals ? 'home' : 'away';
+        if (predictedWinner !== expectedWinner) {
+          return {
+            statusCode: 400,
+            headers: corsHeaders,
+            body: JSON.stringify({ error: 'predicted_winner must match the leading team in the score' }),
+          };
+        }
+      }
+
+      await sql`
+        INSERT INTO wc_predictions (match_id, player_id, prediction, predicted_home_goals, predicted_away_goals, predicted_winner, is_banker, trivia_guess)
+        VALUES (${match_id}, ${player_id}, ${predictedWinner}, ${predictedHomeGoals}, ${predictedAwayGoals}, ${predictedWinner}, ${is_banker}, ${validTriviaGuess})
+        ON CONFLICT (match_id, player_id) DO UPDATE SET
+          prediction = ${predictedWinner},
+          predicted_home_goals = ${predictedHomeGoals},
+          predicted_away_goals = ${predictedAwayGoals},
+          predicted_winner = ${predictedWinner},
+          is_banker = ${is_banker},
+          trivia_guess = ${validTriviaGuess}
+      `;
+    } else {
+      // Group stage: home / draw / away prediction
+      const { prediction } = body;
+      if (!prediction) {
+        return {
+          statusCode: 400,
+          headers: corsHeaders,
+          body: JSON.stringify({ error: "Missing required fields" }),
+        };
+      }
+      if (!["home", "draw", "away"].includes(prediction)) {
+        return {
+          statusCode: 400,
+          headers: corsHeaders,
+          body: JSON.stringify({ error: "Invalid prediction value" }),
+        };
+      }
+      // Upsert — predictions can be changed until the match locks (kickoff guard
+      // above). Re-submitting overwrites the pick, banker flag and trivia guess.
+      // trivia_points is left untouched (awarded later by setWcTriviaResult).
+      await sql`
+        INSERT INTO wc_predictions (match_id, player_id, prediction, is_banker, trivia_guess)
+        VALUES (${match_id}, ${player_id}, ${prediction}, ${is_banker}, ${validTriviaGuess})
+        ON CONFLICT (match_id, player_id)
+        DO UPDATE SET prediction = ${prediction}, is_banker = ${is_banker}, trivia_guess = ${validTriviaGuess}
+      `;
+    }
 
     return {
       statusCode: 200,

--- a/src/pages/WcAdmin.tsx
+++ b/src/pages/WcAdmin.tsx
@@ -501,7 +501,8 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
 
       {/* Activation modal — designate the day's banker match before activating */}
       {activateModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
+        <div className="fixed inset-0 z-50 overflow-y-auto bg-black/70">
+          <div className="flex min-h-full items-center justify-center px-4 py-6">
           <div className="w-full max-w-sm bg-slate-800 border border-slate-700 rounded-2xl overflow-hidden shadow-2xl">
             <div className="px-5 py-4 border-b border-slate-700/60">
               <h3 className="text-white font-bold text-base">Activate match</h3>
@@ -713,6 +714,7 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
                     : 'Activate'}
               </button>
             </div>
+          </div>
           </div>
         </div>
       )}

--- a/src/pages/WcAdmin.tsx
+++ b/src/pages/WcAdmin.tsx
@@ -156,7 +156,7 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [dateInput, setDateInput] = useState(new Date().toISOString().split('T')[0]);
   const [completedExpanded, setCompletedExpanded] = useState(false);
-  const [manualForm, setManualForm] = useState<{ [matchId: number]: { home: string; away: string } }>({});
+  const [manualForm, setManualForm] = useState<{ [matchId: number]: { home: string; away: string; penaltyWinner?: 'home' | 'away' } }>({});
   const [manualOpen, setManualOpen] = useState<number | null>(null);
   const [settingManual, setSettingManual] = useState<number | null>(null);
   const [settingLiveManual, setSettingLiveManual] = useState<number | null>(null);
@@ -446,7 +446,7 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
       const res = await fetch('/.netlify/functions/setWcResultManual', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ match_id: matchId, home_goals: hg, away_goals: ag, override }),
+        body: JSON.stringify({ match_id: matchId, home_goals: hg, away_goals: ag, penalty_winner: form.penaltyWinner ?? null, override }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed to set result');
@@ -968,6 +968,27 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
                                   />
                                 </div>
                               </div>
+                              {/* Penalty winner picker — knockout only, equal scores */}
+                              {m.is_knockout &&
+                                manualForm[m.id]?.home !== '' && manualForm[m.id]?.away !== '' &&
+                                !isNaN(parseInt(manualForm[m.id]?.home ?? '')) &&
+                                parseInt(manualForm[m.id]?.home ?? '') === parseInt(manualForm[m.id]?.away ?? '') && (
+                                <div className="rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-3 space-y-2">
+                                  <p className="text-amber-300 text-xs font-bold uppercase tracking-wider">Who advanced on penalties?</p>
+                                  <div className="flex gap-2">
+                                    {(['home', 'away'] as const).map((side) => (
+                                      <button
+                                        key={side}
+                                        type="button"
+                                        onClick={() => setManualForm((prev) => ({ ...prev, [m.id]: { ...prev[m.id], penaltyWinner: side } }))}
+                                        className={`flex-1 py-2 rounded-xl text-sm font-semibold border transition-colors ${manualForm[m.id]?.penaltyWinner === side ? 'bg-amber-500 border-amber-400 text-white' : 'bg-slate-700 border-slate-600 text-slate-300 hover:bg-slate-600'}`}
+                                      >
+                                        {side === 'home' ? m.home_team : m.away_team}
+                                      </button>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
                               <div className="flex gap-2">
                                 <button
                                   onClick={() => setLiveScoreManually(m.id)}
@@ -987,7 +1008,10 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
                                     settingManual === m.id ||
                                     settingLiveManual === m.id ||
                                     !manualForm[m.id]?.home ||
-                                    !manualForm[m.id]?.away
+                                    !manualForm[m.id]?.away ||
+                                    (m.is_knockout &&
+                                      parseInt(manualForm[m.id]?.home ?? '') === parseInt(manualForm[m.id]?.away ?? '') &&
+                                      !manualForm[m.id]?.penaltyWinner)
                                   }
                                   className="flex-1 py-2.5 bg-green-600 hover:bg-green-700 active:bg-green-800 disabled:bg-slate-700 disabled:text-slate-500 text-white font-semibold rounded-xl transition-colors text-sm"
                                 >
@@ -1126,12 +1150,36 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
                                           />
                                         </div>
                                       </div>
+                                      {/* Penalty winner picker — knockout only, equal scores */}
+                                      {m.is_knockout &&
+                                        manualForm[m.id]?.home !== '' && manualForm[m.id]?.away !== '' &&
+                                        !isNaN(parseInt(manualForm[m.id]?.home ?? '')) &&
+                                        parseInt(manualForm[m.id]?.home ?? '') === parseInt(manualForm[m.id]?.away ?? '') && (
+                                        <div className="rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-3 space-y-2">
+                                          <p className="text-amber-300 text-xs font-bold uppercase tracking-wider">Who advanced on penalties?</p>
+                                          <div className="flex gap-2">
+                                            {(['home', 'away'] as const).map((side) => (
+                                              <button
+                                                key={side}
+                                                type="button"
+                                                onClick={() => setManualForm((prev) => ({ ...prev, [m.id]: { ...prev[m.id], penaltyWinner: side } }))}
+                                                className={`flex-1 py-2 rounded-xl text-sm font-semibold border transition-colors ${manualForm[m.id]?.penaltyWinner === side ? 'bg-amber-500 border-amber-400 text-white' : 'bg-slate-700 border-slate-600 text-slate-300 hover:bg-slate-600'}`}
+                                              >
+                                                {side === 'home' ? m.home_team : m.away_team}
+                                              </button>
+                                            ))}
+                                          </div>
+                                        </div>
+                                      )}
                                       <button
                                         onClick={() => setResultManually(m.id, true)}
                                         disabled={
                                           settingManual === m.id ||
                                           !manualForm[m.id]?.home ||
-                                          !manualForm[m.id]?.away
+                                          !manualForm[m.id]?.away ||
+                                          (m.is_knockout &&
+                                            parseInt(manualForm[m.id]?.home ?? '') === parseInt(manualForm[m.id]?.away ?? '') &&
+                                            !manualForm[m.id]?.penaltyWinner)
                                         }
                                         className="w-full py-2.5 bg-amber-600 hover:bg-amber-700 active:bg-amber-800 disabled:bg-slate-700 disabled:text-slate-500 text-white font-semibold rounded-xl transition-colors text-sm"
                                       >

--- a/src/pages/WcAdmin.tsx
+++ b/src/pages/WcAdmin.tsx
@@ -30,6 +30,7 @@ interface ActiveMatch {
   final_home_goals: number | null;
   final_away_goals: number | null;
   is_banker_match: boolean;
+  is_knockout: boolean;
   trivia_question: string | null;
   trivia_options: string | null; // JSON array string
   trivia_answer: number | null; // null = unset, -1 = none, >=0 = correct index
@@ -163,6 +164,7 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
   const [activateModal, setActivateModal] = useState<{
     fixture: Fixture;
     banker: boolean;
+    isKnockout: boolean;
     triviaQuestion: string;
     triviaOptions: string[];
   } | null>(null);
@@ -242,6 +244,7 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
   const activateMatch = async (
     fixture: Fixture,
     isBankerMatch: boolean,
+    isKnockout: boolean,
     triviaQuestion: string,
     triviaOptions: string[]
   ) => {
@@ -265,6 +268,7 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
           away_flag: fixture.away_flag,
           kickoff_time: fixture.kickoff_time,
           is_banker_match: isBankerMatch,
+          is_knockout: isKnockout,
           trivia_question: sendTrivia ? q : null,
           trivia_options: sendTrivia ? opts : null,
         }),
@@ -577,6 +581,37 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
                 </>
               )}
 
+              {/* Knockout toggle — pre-checked for Round of 32 onwards */}
+              <button
+                type="button"
+                onClick={() => setActivateModal((s) => (s ? { ...s, isKnockout: !s.isKnockout } : s))}
+                className={`w-full flex items-center gap-3 rounded-xl px-4 py-3 border text-left transition-colors ${
+                  activateModal.isKnockout
+                    ? 'bg-green-500/15 border-green-500/50'
+                    : 'bg-slate-700/40 border-slate-600/50 hover:border-slate-500'
+                }`}
+              >
+                <span className="min-w-0 flex-1">
+                  <span className={`block text-sm font-bold ${activateModal.isKnockout ? 'text-green-200' : 'text-slate-200'}`}>
+                    Knockout match
+                  </span>
+                  <span className="block text-xs text-slate-400 mt-0.5">
+                    Scoreline prediction · +5 exact score · +1 winner
+                  </span>
+                </span>
+                <span
+                  className={`flex-shrink-0 w-10 h-6 rounded-full transition-colors relative ${
+                    activateModal.isKnockout ? 'bg-green-500' : 'bg-slate-600'
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 w-5 h-5 rounded-full bg-white transition-all ${
+                      activateModal.isKnockout ? 'left-[1.125rem]' : 'left-0.5'
+                    }`}
+                  />
+                </span>
+              </button>
+
               {/* Optional bonus trivia (multiple choice) — set at activation only */}
               <div className="rounded-xl bg-sky-500/10 border border-sky-500/30 px-4 py-3 space-y-2">
                 <div className="flex items-center gap-1.5">
@@ -663,6 +698,7 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
                   activateMatch(
                     activateModal.fixture,
                     activateModal.banker,
+                    activateModal.isKnockout,
                     activateModal.triviaQuestion,
                     activateModal.triviaOptions
                   )
@@ -1178,6 +1214,7 @@ const WcAdmin: React.FC<{ isAdmin: boolean }> = ({ isAdmin }) => {
                           setActivateModal({
                             fixture: fix,
                             banker: false,
+                            isKnockout: true,
                             triviaQuestion: '',
                             triviaOptions: ['', ''],
                           })

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -831,25 +831,17 @@ function ActiveMatchCard({
             <div className="space-y-3">
               <div className="flex items-center gap-3">
                 {/* Home goals */}
-                <div className="flex-1 flex flex-col items-center gap-2">
-                  <FlagImg src={match.home_flag} alt={match.home_team} />
-                  <span className="text-xs text-slate-300 font-semibold text-center leading-tight">{match.home_team}</span>
-                  <div className="flex items-center gap-3">
-                    <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
-                    <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedHomeGoals ?? '?'}</span>
-                    <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
-                  </div>
+                <div className="flex-1 flex items-center justify-center gap-3">
+                  <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
+                  <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedHomeGoals ?? '?'}</span>
+                  <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
                 </div>
                 <span className="text-slate-500 font-black text-2xl flex-shrink-0">–</span>
                 {/* Away goals */}
-                <div className="flex-1 flex flex-col items-center gap-2">
-                  <FlagImg src={match.away_flag} alt={match.away_team} />
-                  <span className="text-xs text-slate-300 font-semibold text-center leading-tight">{match.away_team}</span>
-                  <div className="flex items-center gap-3">
-                    <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
-                    <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedAwayGoals ?? '?'}</span>
-                    <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
-                  </div>
+                <div className="flex-1 flex items-center justify-center gap-3">
+                  <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
+                  <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedAwayGoals ?? '?'}</span>
+                  <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
                 </div>
               </div>
               {/* Winner — auto-locked for non-equal score, required picker for equal (pens) */}

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -391,7 +391,7 @@ function PredictionsList({
                       {pred.player_name}
                       {pred.is_banker && <BankerStar />}
                     </span>
-                    {isCompleted && <PointsBadge points={pred.points} />}
+                    {isCompleted && <PointsBadge points={activePick === 'score' ? (pred.score_points || 0) : pred.points} />}
                   </div>
                 ))}
               </div>

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -33,6 +33,7 @@ interface Match {
   final_home_goals: number | null;
   final_away_goals: number | null;
   is_banker_match: boolean;
+  is_knockout: boolean;
   trivia_question: string | null;
   trivia_options: string | null; // JSON array string, e.g. '["0","1","2","3+"]'
   trivia_answer: number | null; // correct index; null = unset, -1 = none of the options
@@ -46,9 +47,14 @@ interface Prediction {
   player_photo: string;
   prediction: string;
   points: number;
+  score_points: number;
   is_banker: boolean;
   trivia_guess: number | null;
   trivia_points: number;
+  // Knockout-only fields (null for group stage predictions)
+  predicted_home_goals: number | null;
+  predicted_away_goals: number | null;
+  predicted_winner: string | null;
 }
 
 interface Player {
@@ -302,11 +308,17 @@ function PredictionsList({
   if (predictions.length === 0) return null;
 
   const isCompleted = match.status === 'completed';
-  const picks = [
-    { val: 'home' as const, label: match.home_team },
-    { val: 'draw' as const, label: 'Draw' },
-    { val: 'away' as const, label: match.away_team },
-  ];
+  // For knockout, prediction column stores the winner ('home'/'away'). No draw tab.
+  const picks = match.is_knockout
+    ? [
+        { val: 'home' as const, label: match.home_team },
+        { val: 'away' as const, label: match.away_team },
+      ]
+    : [
+        { val: 'home' as const, label: match.home_team },
+        { val: 'draw' as const, label: 'Draw' },
+        { val: 'away' as const, label: match.away_team },
+      ];
   const votersFor = (val: 'home' | 'draw' | 'away') =>
     predictions.filter((p) => p.prediction === val);
   const activeVoters = activePick ? votersFor(activePick) : [];
@@ -316,7 +328,7 @@ function PredictionsList({
     <div className="border-t border-slate-700/50">
       {/* Vote breakdown — tap a side to see who picked it */}
       <div className="px-5 pt-3 pb-1">
-        <div className="grid grid-cols-3 gap-2">
+        <div className={`grid gap-2 ${match.is_knockout ? 'grid-cols-2' : 'grid-cols-3'}`}>
           {picks.map(({ val, label }) => {
             const count = votersFor(val).length;
             const active = activePick === val;
@@ -395,13 +407,15 @@ function PredictionsList({
                 {pred.is_banker && <BankerStar />}
               </span>
               <span className="text-xs text-slate-400">
-                {pred.prediction === 'home'
-                  ? match.home_team
-                  : pred.prediction === 'away'
-                    ? match.away_team
-                    : 'Draw'}
+                {match.is_knockout && pred.predicted_home_goals !== null
+                  ? `${pred.predicted_home_goals}–${pred.predicted_away_goals}`
+                  : pred.prediction === 'home'
+                    ? match.home_team
+                    : pred.prediction === 'away'
+                      ? match.away_team
+                      : 'Draw'}
               </span>
-              {isCompleted && <PointsBadge points={pred.points} />}
+              {isCompleted && <PointsBadge points={(pred.points || 0) + (pred.score_points || 0)} />}
             </div>
           ))}
         </div>
@@ -419,8 +433,14 @@ function BankersSummary({ match }: { match: Match }) {
   const [open, setOpen] = useState(false);
   const bankers = match.predictions.filter((p) => p.is_banker);
   const isCompleted = match.status === 'completed';
-  const pickLabel = (val: string) =>
-    val === 'home' ? match.home_team : val === 'away' ? match.away_team : 'Draw';
+  const pickLabel = (b: Prediction) =>
+    match.is_knockout && b.predicted_home_goals !== null
+      ? `${b.predicted_home_goals}–${b.predicted_away_goals}`
+      : b.prediction === 'home'
+        ? match.home_team
+        : b.prediction === 'away'
+          ? match.away_team
+          : 'Draw';
 
   if (bankers.length === 0) {
     return (
@@ -459,7 +479,7 @@ function BankersSummary({ match }: { match: Match }) {
                 <span className="text-white text-sm font-medium flex-1 min-w-0 truncate">
                   {b.player_name}
                 </span>
-                <span className="text-xs text-slate-300">{pickLabel(b.prediction)}</span>
+                <span className="text-xs text-slate-300">{pickLabel(b)}</span>
                 {isCompleted && <PointsBadge points={b.points} />}
               </div>
             ))}
@@ -571,6 +591,10 @@ function ActiveMatchCard({
   bankerUsedToday: boolean;
 }) {
   const [selectedPrediction, setSelectedPrediction] = useState<string | null>(null);
+  // Knockout-specific prediction state
+  const [predictedHomeGoals, setPredictedHomeGoals] = useState<number | null>(null);
+  const [predictedAwayGoals, setPredictedAwayGoals] = useState<number | null>(null);
+  const [predictedWinner, setPredictedWinner] = useState<'home' | 'away' | null>(null);
   const [banker, setBanker] = useState(false);
   const [triviaGuess, setTriviaGuess] = useState<number | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -591,6 +615,9 @@ function ActiveMatchCard({
   useEffect(() => {
     if (!selectedPlayer) {
       setSelectedPrediction(null);
+      setPredictedHomeGoals(null);
+      setPredictedAwayGoals(null);
+      setPredictedWinner(null);
       setSubmitted(false);
       setBanker(false);
       setTriviaGuess(null);
@@ -598,35 +625,77 @@ function ActiveMatchCard({
     }
     const existing = match.predictions.find((p) => p.player_id === selectedPlayer);
     if (existing) {
-      setSelectedPrediction(existing.prediction);
-      // Seed the banker toggle and trivia guess from the saved pick so an edit
-      // reflects reality.
+      if (match.is_knockout) {
+        setPredictedHomeGoals(existing.predicted_home_goals ?? null);
+        setPredictedAwayGoals(existing.predicted_away_goals ?? null);
+        setPredictedWinner((existing.predicted_winner ?? null) as 'home' | 'away' | null);
+      } else {
+        setSelectedPrediction(existing.prediction);
+      }
       setBanker(existing.is_banker);
       setTriviaGuess(existing.trivia_guess);
       setSubmitted(true);
     } else {
       setSelectedPrediction(null);
+      setPredictedHomeGoals(null);
+      setPredictedAwayGoals(null);
+      setPredictedWinner(null);
       setSubmitted(false);
       setBanker(false);
       setTriviaGuess(null);
     }
-  }, [selectedPlayer, match.predictions]);
+  }, [selectedPlayer, match.predictions, match.is_knockout]);
+
+  const handleHomeGoalsChange = (newVal: number) => {
+    const clamped = Math.max(0, Math.min(15, newVal));
+    setPredictedHomeGoals(clamped);
+    if (predictedAwayGoals !== null) {
+      if (clamped > predictedAwayGoals) setPredictedWinner('home');
+      else if (clamped < predictedAwayGoals) setPredictedWinner('away');
+      else setPredictedWinner(null);
+    }
+  };
+
+  const handleAwayGoalsChange = (newVal: number) => {
+    const clamped = Math.max(0, Math.min(15, newVal));
+    setPredictedAwayGoals(clamped);
+    if (predictedHomeGoals !== null) {
+      if (predictedHomeGoals > clamped) setPredictedWinner('home');
+      else if (predictedHomeGoals < clamped) setPredictedWinner('away');
+      else setPredictedWinner(null);
+    }
+  };
 
   const handleSubmit = async () => {
-    if (!selectedPlayer || !selectedPrediction) return;
+    if (match.is_knockout) {
+      if (predictedHomeGoals === null || predictedAwayGoals === null || !predictedWinner) return;
+    } else {
+      if (!selectedPlayer || !selectedPrediction) return;
+    }
     setSubmitting(true);
     setError(null);
     try {
+      const payload = match.is_knockout
+        ? {
+            match_id: match.id,
+            player_id: selectedPlayer,
+            predicted_home_goals: predictedHomeGoals,
+            predicted_away_goals: predictedAwayGoals,
+            predicted_winner: predictedWinner,
+            is_banker: banker,
+            trivia_guess: hasTrivia ? triviaGuess : null,
+          }
+        : {
+            match_id: match.id,
+            player_id: selectedPlayer,
+            prediction: selectedPrediction,
+            is_banker: banker,
+            trivia_guess: hasTrivia ? triviaGuess : null,
+          };
       const res = await fetch('/.netlify/functions/submitPrediction', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          match_id: match.id,
-          player_id: selectedPlayer,
-          prediction: selectedPrediction,
-          is_banker: banker,
-          trivia_guess: hasTrivia ? triviaGuess : null,
-        }),
+        body: JSON.stringify(payload),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Submission failed');
@@ -715,13 +784,21 @@ function ActiveMatchCard({
               <div className="min-w-0">
                 <p className="text-green-300 text-sm font-semibold flex items-center gap-1.5 flex-wrap">
                   Your prediction:{' '}
-                  <span className="text-white">
-                    {selectedPrediction === 'home'
-                      ? match.home_team
-                      : selectedPrediction === 'away'
-                        ? match.away_team
-                        : 'Draw'}
-                  </span>
+                  {match.is_knockout ? (
+                    <span className="text-white">
+                      {match.home_team} {myPrediction?.predicted_home_goals ?? '?'}–{myPrediction?.predicted_away_goals ?? '?'} {match.away_team}
+                      {' · '}
+                      {myPrediction?.predicted_winner === 'home' ? match.home_team : match.away_team} to advance
+                    </span>
+                  ) : (
+                    <span className="text-white">
+                      {selectedPrediction === 'home'
+                        ? match.home_team
+                        : selectedPrediction === 'away'
+                          ? match.away_team
+                          : 'Draw'}
+                    </span>
+                  )}
                   {myPrediction?.is_banker && (
                     <span className="inline-flex items-center gap-1 text-amber-300 bg-amber-500/15 border border-amber-500/30 px-2 py-0.5 rounded-full text-xs font-bold">
                       <BankerStar size={11} /> Banker
@@ -749,26 +826,88 @@ function ActiveMatchCard({
 
       {!isLocked && selectedPlayer && !submitted && (
         <div className="px-6 pb-6 space-y-3 border-t border-slate-700/50 pt-4">
-          <div className="grid grid-cols-3 gap-2">
-            {(['home', 'draw', 'away'] as const).map((val) => {
-              const label =
-                val === 'home' ? match.home_team : val === 'away' ? match.away_team : 'Draw';
-              const isSelected = selectedPrediction === val;
-              return (
-                <button
-                  key={val}
-                  onClick={() => setSelectedPrediction(val)}
-                  className={`py-3 px-2 rounded-xl text-xs font-bold transition-all duration-200 border ${
-                    isSelected
-                      ? 'bg-green-600 border-green-500 text-white shadow-lg shadow-green-600/30'
-                      : 'bg-slate-700 border-slate-600 text-slate-300 hover:border-slate-500 hover:text-white'
-                  }`}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
+          {match.is_knockout ? (
+            // ── Knockout: scoreline + winner ──────────────────────────────
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                {/* Home goals */}
+                <div className="flex-1 flex flex-col items-center gap-2">
+                  <FlagImg src={match.home_flag} alt={match.home_team} />
+                  <span className="text-xs text-slate-300 font-semibold text-center leading-tight">{match.home_team}</span>
+                  <div className="flex items-center gap-3">
+                    <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
+                    <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedHomeGoals ?? '?'}</span>
+                    <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
+                  </div>
+                </div>
+                <span className="text-slate-500 font-black text-2xl flex-shrink-0">–</span>
+                {/* Away goals */}
+                <div className="flex-1 flex flex-col items-center gap-2">
+                  <FlagImg src={match.away_flag} alt={match.away_team} />
+                  <span className="text-xs text-slate-300 font-semibold text-center leading-tight">{match.away_team}</span>
+                  <div className="flex items-center gap-3">
+                    <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
+                    <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedAwayGoals ?? '?'}</span>
+                    <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
+                  </div>
+                </div>
+              </div>
+              {/* Winner — auto-locked for non-equal score, required picker for equal (pens) */}
+              {predictedHomeGoals !== null && predictedAwayGoals !== null && (
+                predictedHomeGoals !== predictedAwayGoals ? (
+                  <div className="flex items-center gap-2 rounded-xl bg-slate-700/40 border border-slate-600/50 px-4 py-2.5">
+                    <CheckCircle2 size={14} className="text-slate-400 flex-shrink-0" />
+                    <span className="text-slate-300 text-sm">
+                      Advances: <span className="text-white font-semibold">{predictedWinner === 'home' ? match.home_team : match.away_team}</span>
+                    </span>
+                    <span className="ml-auto text-slate-600 text-xs">auto</span>
+                  </div>
+                ) : (
+                  <div className="rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-3 space-y-2">
+                    <p className="text-amber-300 text-xs font-bold uppercase tracking-wider">Who advances on penalties?</p>
+                    <div className="grid grid-cols-2 gap-2">
+                      {(['home', 'away'] as const).map((side) => (
+                        <button
+                          key={side}
+                          type="button"
+                          onClick={() => setPredictedWinner(side)}
+                          className={`py-2 px-3 rounded-xl text-sm font-bold border transition-colors ${
+                            predictedWinner === side
+                              ? 'bg-amber-500/25 border-amber-400/60 text-amber-100'
+                              : 'bg-slate-700/60 border-slate-600/50 text-slate-300 hover:border-slate-500'
+                          }`}
+                        >
+                          {side === 'home' ? match.home_team : match.away_team}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )
+              )}
+            </div>
+          ) : (
+            // ── Group stage: 3-button pick ─────────────────────────────────
+            <div className="grid grid-cols-3 gap-2">
+              {(['home', 'draw', 'away'] as const).map((val) => {
+                const label =
+                  val === 'home' ? match.home_team : val === 'away' ? match.away_team : 'Draw';
+                const isSelected = selectedPrediction === val;
+                return (
+                  <button
+                    key={val}
+                    onClick={() => setSelectedPrediction(val)}
+                    className={`py-3 px-2 rounded-xl text-xs font-bold transition-all duration-200 border ${
+                      isSelected
+                        ? 'bg-green-600 border-green-500 text-white shadow-lg shadow-green-600/30'
+                        : 'bg-slate-700 border-slate-600 text-slate-300 hover:border-slate-500 hover:text-white'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
 
           {/* Banker toggle. Admin mode: only the designated match. User mode: any
              match, but locked out if the player already bankered another game
@@ -854,7 +993,9 @@ function ActiveMatchCard({
             </div>
           )}
 
-          {selectedPrediction && (
+          {(match.is_knockout
+            ? predictedHomeGoals !== null && predictedAwayGoals !== null && predictedWinner !== null
+            : !!selectedPrediction) && (
             <button
               onClick={handleSubmit}
               disabled={submitting}
@@ -867,7 +1008,13 @@ function ActiveMatchCard({
             <button
               type="button"
               onClick={() => {
-                setSelectedPrediction(myPrediction.prediction);
+                if (match.is_knockout) {
+                  setPredictedHomeGoals(myPrediction.predicted_home_goals ?? null);
+                  setPredictedAwayGoals(myPrediction.predicted_away_goals ?? null);
+                  setPredictedWinner((myPrediction.predicted_winner ?? null) as 'home' | 'away' | null);
+                } else {
+                  setSelectedPrediction(myPrediction.prediction);
+                }
                 setBanker(myPrediction.is_banker);
                 setTriviaGuess(myPrediction.trivia_guess);
                 setSubmitted(true);
@@ -1245,7 +1392,7 @@ function buildStandingsHistory(matches: Match[]): { days: string[]; series: StdS
         if (!totals.has(p.player_id)) continue;
         totals.set(
           p.player_id,
-          totals.get(p.player_id)! + (p.points || 0) + (p.trivia_points || 0)
+          totals.get(p.player_id)! + (p.points || 0) + (p.score_points || 0) + (p.trivia_points || 0)
         );
         // Match the leaderboard's "correct" definition: a match pick worth > 0
         // (trivia points don't count toward correctness).

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -367,7 +367,7 @@ function PredictionsList({
                   : 'bg-teal-500/10 border-teal-500/30 text-teal-200 hover:border-teal-400/50'
               }`}
             >
-              <span className="leading-tight">Perfect</span>
+              <span className="leading-tight">🎯 Exact ⚽</span>
               <span className={`text-[10px] tabular-nums leading-tight ${activePick === 'score' ? 'text-slate-300' : 'text-teal-300/70'}`}>
                 {match.final_home_goals}–{match.final_away_goals}
               </span>

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -367,7 +367,8 @@ function PredictionsList({
                   : 'bg-teal-500/10 border-teal-500/30 text-teal-200 hover:border-teal-400/50'
               }`}
             >
-              <span className="leading-tight font-black tabular-nums">
+              <span className="leading-tight">Perfect</span>
+              <span className={`text-[10px] tabular-nums leading-tight ${activePick === 'score' ? 'text-slate-300' : 'text-teal-300/70'}`}>
                 {match.final_home_goals}–{match.final_away_goals}
               </span>
               <span className={`text-base font-black leading-none ${activePick === 'score' ? 'text-green-300' : 'text-teal-300'}`}>

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -387,10 +387,15 @@ function PredictionsList({
                 {activeVoters.map((pred) => (
                   <div key={pred.player_id} className="flex items-center gap-3 px-4 py-2.5">
                     <PlayerAvatar photo={pred.player_photo} name={pred.player_name} size={7} />
-                    <span className="text-white text-sm font-medium flex-1 flex items-center gap-1.5">
-                      {pred.player_name}
+                    <span className="text-white text-sm font-medium flex-1 flex items-center gap-1.5 min-w-0">
+                      <span className="truncate">{pred.player_name}</span>
                       {pred.is_banker && <BankerStar />}
                     </span>
+                    {match.is_knockout && pred.predicted_home_goals != null && (
+                      <span className="text-slate-400 text-xs tabular-nums shrink-0">
+                        {pred.predicted_home_goals}–{pred.predicted_away_goals}
+                      </span>
+                    )}
                     {isCompleted && <PointsBadge points={activePick === 'score' ? (pred.score_points || 0) : pred.points} />}
                   </div>
                 ))}

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -425,9 +425,9 @@ function PredictionsList({
                 {pred.player_name}
                 {pred.is_banker && <BankerStar />}
               </span>
-              <span className="text-xs text-slate-400">
+              <span className="text-xs text-slate-400 text-right">
                 {match.is_knockout && pred.predicted_home_goals !== null
-                  ? `${pred.predicted_home_goals}–${pred.predicted_away_goals}`
+                  ? `${pred.predicted_home_goals}–${pred.predicted_away_goals}${pred.predicted_winner ? ` · ${pred.predicted_winner === 'home' ? match.home_team : match.away_team}` : ''}`
                   : pred.prediction === 'home'
                     ? match.home_team
                     : pred.prediction === 'away'
@@ -454,7 +454,7 @@ function BankersSummary({ match }: { match: Match }) {
   const isCompleted = match.status === 'completed';
   const pickLabel = (b: Prediction) =>
     match.is_knockout && b.predicted_home_goals !== null
-      ? `${b.predicted_home_goals}–${b.predicted_away_goals}`
+      ? `${b.predicted_home_goals}–${b.predicted_away_goals}${b.predicted_winner ? ` · ${b.predicted_winner === 'home' ? match.home_team : match.away_team}` : ''}`
       : b.prediction === 'home'
         ? match.home_team
         : b.prediction === 'away'

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -303,7 +303,7 @@ function PredictionsList({
   defaultOpen?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
-  const [activePick, setActivePick] = useState<'home' | 'draw' | 'away' | null>(null);
+  const [activePick, setActivePick] = useState<'home' | 'draw' | 'away' | 'score' | null>(null);
 
   if (predictions.length === 0) return null;
 
@@ -321,14 +321,15 @@ function PredictionsList({
       ];
   const votersFor = (val: 'home' | 'draw' | 'away') =>
     predictions.filter((p) => p.prediction === val);
-  const activeVoters = activePick ? votersFor(activePick) : [];
-  const activeLabel = picks.find((p) => p.val === activePick)?.label ?? '';
+  const scorerVoters = predictions.filter((p) => (p.score_points ?? 0) > 0);
+  const activeVoters = activePick === 'score' ? scorerVoters : activePick ? votersFor(activePick) : [];
+  const activeLabel = activePick === 'score' ? 'the exact score' : picks.find((p) => p.val === activePick)?.label ?? '';
 
   return (
     <div className="border-t border-slate-700/50">
       {/* Vote breakdown — tap a side to see who picked it */}
       <div className="px-5 pt-3 pb-1">
-        <div className={`grid gap-2 ${match.is_knockout ? 'grid-cols-2' : 'grid-cols-3'}`}>
+        <div className={`grid gap-2 ${match.is_knockout && isCompleted ? 'grid-cols-3' : match.is_knockout ? 'grid-cols-2' : 'grid-cols-3'}`}>
           {picks.map(({ val, label }) => {
             const count = votersFor(val).length;
             const active = activePick === val;
@@ -356,6 +357,24 @@ function PredictionsList({
               </button>
             );
           })}
+          {/* Exact scoreline filter — knockout completed only */}
+          {match.is_knockout && isCompleted && (
+            <button
+              onClick={() => setActivePick((p) => (p === 'score' ? null : 'score'))}
+              className={`flex flex-col items-center gap-0.5 py-2 px-2 rounded-xl border text-xs font-semibold transition-colors ${
+                activePick === 'score'
+                  ? 'bg-green-600/20 border-green-500/50 text-white'
+                  : 'bg-teal-500/10 border-teal-500/30 text-teal-200 hover:border-teal-400/50'
+              }`}
+            >
+              <span className="leading-tight font-black tabular-nums">
+                {match.final_home_goals}–{match.final_away_goals}
+              </span>
+              <span className={`text-base font-black leading-none ${activePick === 'score' ? 'text-green-300' : 'text-teal-300'}`}>
+                {scorerVoters.length}
+              </span>
+            </button>
+          )}
         </div>
 
         {activePick && (


### PR DESCRIPTION
When tapping Home/Away/Exact buttons on a locked or completed knockout match, each player row now shows their predicted scoreline (e.g. 2–1) alongside their name. Only appears for knockout predictions where a scoreline was entered; group stage rows are unchanged.

Claude-Session: https://claude.ai/code/session_01RvPbu4RhykvbUgyqpE1mJK