### PR TITLE
fix: update banker penalty messaging from -1 to -2 for knockout rounds

### DIFF
--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -284,10 +284,10 @@ function PointsBadge({ points }: { points: number }) {
   );
 }
 
-// Star marking a banker pick (2× points, −1 if wrong).
+// Star marking a banker pick (2× points, −2 if wrong in knockout).
 function BankerStar({ size = 12 }: { size?: number }) {
   return (
-    <span title="Banker · 2× points (−1 if wrong)" className="inline-flex items-center">
+    <span title="Banker · 2× points if correct · −2 if wrong (knockout)" className="inline-flex items-center">
       <Star size={size} className="text-amber-400 fill-amber-400" />
     </span>
   );
@@ -760,7 +760,7 @@ function ActiveMatchCard({
       {bankerMode === 'admin' && match.is_banker_match && (
         <div className="flex items-center justify-center gap-2 px-4 py-2 bg-amber-500/10 border-b border-amber-500/30 text-amber-300 text-xs font-bold tracking-wide">
           <Star size={13} className="fill-amber-400 text-amber-400" />
-          BANKER MATCH · 2× points if correct · −1 if wrong
+          BANKER MATCH · 2× points if correct · {match.is_knockout ? '−2' : '−1'} if wrong
         </div>
       )}
 
@@ -965,7 +965,7 @@ function ActiveMatchCard({
                     Use my Banker
                   </span>
                   <span className="block text-xs text-slate-400 mt-0.5">
-                    2× points if right · −1 if wrong{bankerMode === 'user' ? ' · one per game day' : ''}
+                    2× points if right · {match.is_knockout ? '−2' : '−1'} if wrong{bankerMode === 'user' ? ' · one per game day' : ''}
                   </span>
                 </span>
                 <span
@@ -1334,7 +1334,7 @@ function BankerModeBanner({ mode }: { mode: 'admin' | 'user' }) {
             </p>
             <p className="text-slate-200 text-xs mt-1 leading-snug">
               Bank <span className="text-white font-semibold">any one match per game day</span> — 2× points
-              if right, −1 if wrong. Game days follow the official schedule (US Eastern).
+              if right, −2 if wrong. Game days follow the official schedule (US Eastern).
             </p>
           </div>
         </div>

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -617,8 +617,8 @@ function ActiveMatchCard({
 }) {
   const [selectedPrediction, setSelectedPrediction] = useState<string | null>(null);
   // Knockout-specific prediction state
-  const [predictedHomeGoals, setPredictedHomeGoals] = useState<number | null>(0);
-  const [predictedAwayGoals, setPredictedAwayGoals] = useState<number | null>(0);
+  const [predictedHomeGoals, setPredictedHomeGoals] = useState<number | null>(null);
+  const [predictedAwayGoals, setPredictedAwayGoals] = useState<number | null>(null);
   const [predictedWinner, setPredictedWinner] = useState<'home' | 'away' | null>(null);
   const [banker, setBanker] = useState(false);
   const [triviaGuess, setTriviaGuess] = useState<number | null>(null);
@@ -640,8 +640,8 @@ function ActiveMatchCard({
   useEffect(() => {
     if (!selectedPlayer) {
       setSelectedPrediction(null);
-      setPredictedHomeGoals(0);
-      setPredictedAwayGoals(0);
+      setPredictedHomeGoals(null);
+      setPredictedAwayGoals(null);
       setPredictedWinner(null);
       setSubmitted(false);
       setBanker(false);
@@ -651,8 +651,8 @@ function ActiveMatchCard({
     const existing = match.predictions.find((p) => p.player_id === selectedPlayer);
     if (existing) {
       if (match.is_knockout) {
-        setPredictedHomeGoals(existing.predicted_home_goals ?? 0);
-        setPredictedAwayGoals(existing.predicted_away_goals ?? 0);
+        setPredictedHomeGoals(existing.predicted_home_goals ?? null);
+        setPredictedAwayGoals(existing.predicted_away_goals ?? null);
         setPredictedWinner((existing.predicted_winner ?? null) as 'home' | 'away' | null);
       } else {
         setSelectedPrediction(existing.prediction);
@@ -662,8 +662,8 @@ function ActiveMatchCard({
       setSubmitted(true);
     } else {
       setSelectedPrediction(null);
-      setPredictedHomeGoals(0);
-      setPredictedAwayGoals(0);
+      setPredictedHomeGoals(null);
+      setPredictedAwayGoals(null);
       setPredictedWinner(null);
       setSubmitted(false);
       setBanker(false);
@@ -855,22 +855,24 @@ function ActiveMatchCard({
             // ── Knockout: scoreline + winner ──────────────────────────────
             <div className="space-y-3">
               <p className="text-slate-400 text-xs font-semibold uppercase tracking-wider text-center">Predict the score</p>
-              <div className="flex items-end gap-4">
+              <div className="flex items-end">
                 {/* Home goals */}
                 <div className="flex-1 flex flex-col items-center gap-1.5">
                   <span className="text-slate-400 text-xs font-medium text-center truncate w-full">{match.home_team}</span>
                   <div className="flex items-center gap-2">
                     <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
-                    <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedHomeGoals ?? 0}</span>
+                    <span className={`font-black text-3xl w-8 text-center tabular-nums select-none ${predictedHomeGoals !== null ? 'text-white' : 'text-slate-600'}`}>{predictedHomeGoals ?? 0}</span>
                     <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
                   </div>
                 </div>
+                {/* Divider */}
+                <div className="w-px bg-slate-700 self-stretch mx-3" />
                 {/* Away goals */}
                 <div className="flex-1 flex flex-col items-center gap-1.5">
                   <span className="text-slate-400 text-xs font-medium text-center truncate w-full">{match.away_team}</span>
                   <div className="flex items-center gap-2">
                     <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
-                    <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedAwayGoals ?? 0}</span>
+                    <span className={`font-black text-3xl w-8 text-center tabular-nums select-none ${predictedAwayGoals !== null ? 'text-white' : 'text-slate-600'}`}>{predictedAwayGoals ?? 0}</span>
                     <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
                   </div>
                 </div>

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -640,8 +640,8 @@ function ActiveMatchCard({
   useEffect(() => {
     if (!selectedPlayer) {
       setSelectedPrediction(null);
-      setPredictedHomeGoals(null);
-      setPredictedAwayGoals(null);
+      setPredictedHomeGoals(0);
+      setPredictedAwayGoals(0);
       setPredictedWinner(null);
       setSubmitted(false);
       setBanker(false);
@@ -651,8 +651,8 @@ function ActiveMatchCard({
     const existing = match.predictions.find((p) => p.player_id === selectedPlayer);
     if (existing) {
       if (match.is_knockout) {
-        setPredictedHomeGoals(existing.predicted_home_goals ?? null);
-        setPredictedAwayGoals(existing.predicted_away_goals ?? null);
+        setPredictedHomeGoals(existing.predicted_home_goals ?? 0);
+        setPredictedAwayGoals(existing.predicted_away_goals ?? 0);
         setPredictedWinner((existing.predicted_winner ?? null) as 'home' | 'away' | null);
       } else {
         setSelectedPrediction(existing.prediction);
@@ -662,8 +662,8 @@ function ActiveMatchCard({
       setSubmitted(true);
     } else {
       setSelectedPrediction(null);
-      setPredictedHomeGoals(null);
-      setPredictedAwayGoals(null);
+      setPredictedHomeGoals(0);
+      setPredictedAwayGoals(0);
       setPredictedWinner(null);
       setSubmitted(false);
       setBanker(false);

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -855,19 +855,24 @@ function ActiveMatchCard({
             // ── Knockout: scoreline + winner ──────────────────────────────
             <div className="space-y-3">
               <p className="text-slate-400 text-xs font-semibold uppercase tracking-wider text-center">Predict the score</p>
-              <div className="flex items-center gap-3">
+              <div className="flex items-end gap-4">
                 {/* Home goals */}
-                <div className="flex-1 flex items-center justify-center gap-3">
-                  <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
-                  <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedHomeGoals ?? '?'}</span>
-                  <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
+                <div className="flex-1 flex flex-col items-center gap-1.5">
+                  <span className="text-slate-400 text-xs font-medium text-center truncate w-full">{match.home_team}</span>
+                  <div className="flex items-center gap-2">
+                    <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
+                    <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedHomeGoals ?? 0}</span>
+                    <button type="button" onClick={() => handleHomeGoalsChange((predictedHomeGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
+                  </div>
                 </div>
-                <span className="text-slate-500 font-black text-2xl flex-shrink-0">–</span>
                 {/* Away goals */}
-                <div className="flex-1 flex items-center justify-center gap-3">
-                  <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
-                  <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedAwayGoals ?? '?'}</span>
-                  <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
+                <div className="flex-1 flex flex-col items-center gap-1.5">
+                  <span className="text-slate-400 text-xs font-medium text-center truncate w-full">{match.away_team}</span>
+                  <div className="flex items-center gap-2">
+                    <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? 0) - 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">−</button>
+                    <span className="text-white font-black text-3xl w-8 text-center tabular-nums select-none">{predictedAwayGoals ?? 0}</span>
+                    <button type="button" onClick={() => handleAwayGoalsChange((predictedAwayGoals ?? -1) + 1)} className="w-9 h-9 rounded-full bg-slate-700 hover:bg-slate-600 text-white font-bold text-xl flex items-center justify-center border border-slate-600 transition-colors">+</button>
+                  </div>
                 </div>
               </div>
               {/* Winner — auto-locked for non-equal score, required picker for equal (pens) */}

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -617,8 +617,8 @@ function ActiveMatchCard({
 }) {
   const [selectedPrediction, setSelectedPrediction] = useState<string | null>(null);
   // Knockout-specific prediction state
-  const [predictedHomeGoals, setPredictedHomeGoals] = useState<number | null>(null);
-  const [predictedAwayGoals, setPredictedAwayGoals] = useState<number | null>(null);
+  const [predictedHomeGoals, setPredictedHomeGoals] = useState<number | null>(0);
+  const [predictedAwayGoals, setPredictedAwayGoals] = useState<number | null>(0);
   const [predictedWinner, setPredictedWinner] = useState<'home' | 'away' | null>(null);
   const [banker, setBanker] = useState(false);
   const [triviaGuess, setTriviaGuess] = useState<number | null>(null);
@@ -854,6 +854,7 @@ function ActiveMatchCard({
           {match.is_knockout ? (
             // ── Knockout: scoreline + winner ──────────────────────────────
             <div className="space-y-3">
+              <p className="text-slate-400 text-xs font-semibold uppercase tracking-wider text-center">Predict the score</p>
               <div className="flex items-center gap-3">
                 {/* Home goals */}
                 <div className="flex-1 flex items-center justify-center gap-3">


### PR DESCRIPTION
BANKER MATCH banner and banker toggle now show -2 for knockout matches and -1 for group stage. Global BankerModeBanner and BankerStar tooltip updated to -2 to reflect current knockout round rules.

Claude-Session: https://claude.ai/code/session_01RvPbu4RhykvbUgyqpE1mJK