### PR TITLE
fix: clarify player mode banker toggle — winner penalty only, score risk-free

### DIFF
--- a/netlify/functions/submitPrediction.js
+++ b/netlify/functions/submitPrediction.js
@@ -65,6 +65,9 @@ export const handler = async (event) => {
 
     const match = matches[0];
 
+    // Admin-designated banker matches are always banked — ignore whatever the client sent.
+    const effectiveIsBanker = match.is_banker_match ? true : is_banker;
+
     // Check kickoff time server-side (don't trust client)
     if (new Date(match.kickoff_time) <= new Date()) {
       // Lock the match while we're here
@@ -86,7 +89,7 @@ export const handler = async (event) => {
 
     // Banker validation depends on the global mode (defaults to 'admin' if the
     // settings row/table is absent, preserving current behaviour).
-    if (is_banker) {
+    if (effectiveIsBanker) {
       let bankerMode = "admin";
       try {
         const settings = await sql`SELECT banker_mode FROM wc_settings WHERE id = 1`;
@@ -181,13 +184,13 @@ export const handler = async (event) => {
 
       await sql`
         INSERT INTO wc_predictions (match_id, player_id, prediction, predicted_home_goals, predicted_away_goals, predicted_winner, is_banker, trivia_guess)
-        VALUES (${match_id}, ${player_id}, ${predictedWinner}, ${predictedHomeGoals}, ${predictedAwayGoals}, ${predictedWinner}, ${is_banker}, ${validTriviaGuess})
+        VALUES (${match_id}, ${player_id}, ${predictedWinner}, ${predictedHomeGoals}, ${predictedAwayGoals}, ${predictedWinner}, ${effectiveIsBanker}, ${validTriviaGuess})
         ON CONFLICT (match_id, player_id) DO UPDATE SET
           prediction = ${predictedWinner},
           predicted_home_goals = ${predictedHomeGoals},
           predicted_away_goals = ${predictedAwayGoals},
           predicted_winner = ${predictedWinner},
-          is_banker = ${is_banker},
+          is_banker = ${effectiveIsBanker},
           trivia_guess = ${validTriviaGuess}
       `;
     } else {
@@ -212,9 +215,9 @@ export const handler = async (event) => {
       // trivia_points is left untouched (awarded later by setWcTriviaResult).
       await sql`
         INSERT INTO wc_predictions (match_id, player_id, prediction, is_banker, trivia_guess)
-        VALUES (${match_id}, ${player_id}, ${prediction}, ${is_banker}, ${validTriviaGuess})
+        VALUES (${match_id}, ${player_id}, ${prediction}, ${effectiveIsBanker}, ${validTriviaGuess})
         ON CONFLICT (match_id, player_id)
-        DO UPDATE SET prediction = ${prediction}, is_banker = ${is_banker}, trivia_guess = ${validTriviaGuess}
+        DO UPDATE SET prediction = ${prediction}, is_banker = ${effectiveIsBanker}, trivia_guess = ${validTriviaGuess}
       `;
     }
 

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -707,14 +707,14 @@ function ActiveMatchCard({
             predicted_home_goals: predictedHomeGoals,
             predicted_away_goals: predictedAwayGoals,
             predicted_winner: predictedWinner,
-            is_banker: banker,
+            is_banker: bankerMode === 'admin' && match.is_banker_match ? true : banker,
             trivia_guess: hasTrivia ? triviaGuess : null,
           }
         : {
             match_id: match.id,
             player_id: selectedPlayer,
             prediction: selectedPrediction,
-            is_banker: banker,
+            is_banker: bankerMode === 'admin' && match.is_banker_match ? true : banker,
             trivia_guess: hasTrivia ? triviaGuess : null,
           };
       const res = await fetch('/.netlify/functions/submitPrediction', {
@@ -938,8 +938,15 @@ function ActiveMatchCard({
              match, but locked out if the player already bankered another game
              on the same game day (one per game day). Shown as soon as the form is
              open so the choice is always visible; default is off. */}
-          {(bankerMode === 'user' || match.is_banker_match) &&
-            (bankerUsedToday ? (
+          {bankerMode === 'admin' && match.is_banker_match ? (
+            <div className="flex items-center gap-2 rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-2.5">
+              <Star size={14} className="flex-shrink-0 text-amber-400 fill-amber-400" />
+              <span className="text-amber-300 text-xs font-semibold">
+                Banker is ON for everyone on this match · {match.is_knockout ? '−2' : '−1'} if wrong
+              </span>
+            </div>
+          ) : bankerMode === 'user' ? (
+            bankerUsedToday ? (
               <div className="flex items-center gap-2 rounded-xl bg-slate-700/30 border border-slate-600/40 px-4 py-2.5 text-slate-400 text-xs">
                 <Star size={14} className="flex-shrink-0 text-slate-500" />
                 Banker already used for another game this game day — one per game day.
@@ -965,7 +972,7 @@ function ActiveMatchCard({
                     Use my Banker
                   </span>
                   <span className="block text-xs text-slate-400 mt-0.5">
-                    2× points if right · {match.is_knockout ? '−2' : '−1'} if wrong{bankerMode === 'user' ? ' · one per game day' : ''}
+                    2× points if right · {match.is_knockout ? '−2' : '−1'} if wrong · one per game day
                   </span>
                 </span>
                 <span
@@ -980,7 +987,8 @@ function ActiveMatchCard({
                   />
                 </span>
               </button>
-            ))}
+            )
+          ) : null}
 
           {/* Bonus trivia — optional multiple-choice question for this match */}
           {hasTrivia && (

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -954,11 +954,16 @@ function ActiveMatchCard({
           )}
 
           {bankerMode === 'admin' && match.is_banker_match ? (
-            <div className="flex items-center gap-2 rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-2.5">
-              <Star size={14} className="flex-shrink-0 text-amber-400 fill-amber-400" />
-              <span className="text-amber-300 text-xs font-semibold">
-                Banker is ON for everyone on this match · {match.is_knockout ? '−2' : '−1'} if wrong
-              </span>
+            <div className="flex items-start gap-2 rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-2.5">
+              <Star size={14} className="flex-shrink-0 text-amber-400 fill-amber-400 mt-0.5" />
+              <div className="flex flex-col gap-0.5">
+                <span className="text-amber-300 text-xs font-semibold">
+                  Banker ON for everyone · 2× if correct winner · {match.is_knockout ? '−2' : '−1'} if wrong
+                </span>
+                {match.is_knockout && (
+                  <span className="text-amber-400/70 text-xs">⚽ Exact score bonus (+5) is separate — no risk</span>
+                )}
+              </div>
             </div>
           ) : bankerMode === 'user' ? (
             bankerUsedToday ? (

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -992,8 +992,11 @@ function ActiveMatchCard({
                     Use my Banker
                   </span>
                   <span className="block text-xs text-slate-400 mt-0.5">
-                    2× points if right · {match.is_knockout ? '−2' : '−1'} if wrong · one per game day
+                    2× if correct winner · {match.is_knockout ? '−2' : '−1'} if wrong winner · one per game day
                   </span>
+                  {match.is_knockout && (
+                    <span className="block text-xs text-slate-500 mt-0.5">⚽ Exact score bonus (+5) is separate — no risk</span>
+                  )}
                 </span>
                 <span
                   className={`flex-shrink-0 w-10 h-6 rounded-full transition-colors relative ${

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -606,6 +606,7 @@ function ActiveMatchCard({
   onPredicted,
   bankerMode,
   bankerUsedToday,
+  isLastUnpredictedToday,
 }: {
   match: Match;
   selectedPlayer: number | null;
@@ -614,6 +615,8 @@ function ActiveMatchCard({
   bankerMode: 'admin' | 'user';
   // User mode only: the player already bankered another game this game day.
   bankerUsedToday: boolean;
+  // User mode only: all other matches today are already predicted — banker is now mandatory.
+  isLastUnpredictedToday: boolean;
 }) {
   const [selectedPrediction, setSelectedPrediction] = useState<string | null>(null);
   // Knockout-specific prediction state
@@ -938,6 +941,18 @@ function ActiveMatchCard({
              match, but locked out if the player already bankered another game
              on the same game day (one per game day). Shown as soon as the form is
              open so the choice is always visible; default is off. */}
+          {/* User mode banker reminder — shown on every match until banker is used */}
+          {bankerMode === 'user' && !bankerUsedToday && (
+            <div className="flex items-center gap-2 rounded-xl bg-amber-500/10 border border-amber-500/20 px-3 py-2">
+              <Star size={13} className="flex-shrink-0 text-amber-400 fill-amber-400" />
+              <span className="text-amber-300 text-xs">
+                {isLastUnpredictedToday
+                  ? 'This is your last match today — banker is required before you can submit.'
+                  : 'You must use your banker on at least one match today.'}
+              </span>
+            </div>
+          )}
+
           {bankerMode === 'admin' && match.is_banker_match ? (
             <div className="flex items-center gap-2 rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-2.5">
               <Star size={14} className="flex-shrink-0 text-amber-400 fill-amber-400" />
@@ -1031,7 +1046,7 @@ function ActiveMatchCard({
             : !!selectedPrediction) && (
             <button
               onClick={handleSubmit}
-              disabled={submitting}
+              disabled={submitting || (isLastUnpredictedToday && !bankerUsedToday && !banker)}
               className="w-full py-3 bg-green-600 hover:bg-green-700 text-white font-bold rounded-xl transition-colors disabled:opacity-50 text-sm"
             >
               {submitting ? 'Saving...' : myPrediction ? 'Save changes' : 'Submit Prediction'}
@@ -2092,6 +2107,16 @@ const WcPredict: React.FC = () => {
     }
   }
 
+  // User mode only: is this the last match of the day the player hasn't predicted yet?
+  // If so, banker becomes mandatory before they can submit.
+  const isLastUnpredictedToday = (match: Match): boolean => {
+    if (!selectedPlayer || bankerMode !== 'user') return false;
+    const day = gameDay(match.kickoff_time);
+    return activeMatches
+      .filter((m) => m.id !== match.id && gameDay(m.kickoff_time) === day)
+      .every((m) => m.predictions.some((p) => p.player_id === selectedPlayer));
+  };
+
   return (
     <div className="min-h-screen bg-slate-900 pb-16">
       {/* Header */}
@@ -2179,6 +2204,7 @@ const WcPredict: React.FC = () => {
                 bankerMatchByDay.has(gameDay(match.kickoff_time)) &&
                 bankerMatchByDay.get(gameDay(match.kickoff_time)) !== match.id
               }
+              isLastUnpredictedToday={isLastUnpredictedToday(match)}
             />
           ))
         )}


### PR DESCRIPTION
2× if correct winner · −2 if wrong winner · one per game day ⚽ Exact score bonus (+5) is separate — no risk

Claude-Session: https://claude.ai/code/session_01RvPbu4RhykvbUgyqpE1mJK