### PR TITLE
feat: atomic banker swap — move banker between matches instead of blocking

### DIFF
--- a/netlify/functions/submitPrediction.js
+++ b/netlify/functions/submitPrediction.js
@@ -111,29 +111,21 @@ export const handler = async (event) => {
           };
         }
       } else {
-        // User mode: banker any match, but at most one per game day.
-        // Exclude this match so re-submitting/editing the same pick doesn't clash
-        // with its own existing banker row.
+        // User mode: one banker per game day — atomic swap if player already
+        // has a banker on another match today (moves it here instead of rejecting).
         const matchDay = gameDay(match.kickoff_time);
         const existingBankers = await sql`
-          SELECT m.kickoff_time
+          SELECT wp.match_id, m.kickoff_time
           FROM wc_predictions wp
           JOIN wc_matches m ON m.id = wp.match_id
           WHERE wp.player_id = ${player_id}
             AND wp.is_banker = TRUE
             AND wp.match_id <> ${match_id}
         `;
-        const clash = existingBankers.some(
-          (b) => gameDay(b.kickoff_time) === matchDay
-        );
-        if (clash) {
-          return {
-            statusCode: 409,
-            headers: corsHeaders,
-            body: JSON.stringify({
-              error: "You've already used your Banker for this day",
-            }),
-          };
+        for (const b of existingBankers) {
+          if (gameDay(b.kickoff_time) === matchDay) {
+            await sql`UPDATE wc_predictions SET is_banker = FALSE WHERE player_id = ${player_id} AND match_id = ${b.match_id}`;
+          }
         }
       }
     }

--- a/src/pages/WcPredict.tsx
+++ b/src/pages/WcPredict.tsx
@@ -966,13 +966,7 @@ function ActiveMatchCard({
               </div>
             </div>
           ) : bankerMode === 'user' ? (
-            bankerUsedToday ? (
-              <div className="flex items-center gap-2 rounded-xl bg-slate-700/30 border border-slate-600/40 px-4 py-2.5 text-slate-400 text-xs">
-                <Star size={14} className="flex-shrink-0 text-slate-500" />
-                Banker already used for another game this game day — one per game day.
-              </div>
-            ) : (
-              <button
+            <button
                 type="button"
                 onClick={() => setBanker((b) => !b)}
                 className={`w-full flex items-center gap-3 rounded-xl px-4 py-3 border text-left transition-colors ${
@@ -989,10 +983,12 @@ function ActiveMatchCard({
                   <span
                     className={`block text-sm font-bold ${banker ? 'text-amber-200' : 'text-slate-200'}`}
                   >
-                    Use my Banker
+                    {bankerUsedToday && !banker ? 'Move Banker here' : 'Use my Banker'}
                   </span>
                   <span className="block text-xs text-slate-400 mt-0.5">
-                    2× if correct winner · {match.is_knockout ? '−2' : '−1'} if wrong winner · one per game day
+                    {bankerUsedToday && !banker
+                      ? 'Removes it from today\'s other match · 2× if correct winner'
+                      : `2× if correct winner · ${match.is_knockout ? '−2' : '−1'} if wrong winner · one per game day`}
                   </span>
                   {match.is_knockout && (
                     <span className="block text-xs text-slate-500 mt-0.5">⚽ Exact score bonus (+5) is separate — no risk</span>
@@ -1010,7 +1006,6 @@ function ActiveMatchCard({
                   />
                 </span>
               </button>
-            )
           ) : null}
 
           {/* Bonus trivia — optional multiple-choice question for this match */}


### PR DESCRIPTION
Backend: when submitting with is_banker=true and another match today already has the banker, strip it from that match before saving (one per day enforced via last-write-wins instead of 409 rejection).

Frontend: replace locked "banker used" pill with unlocked "Move Banker here" toggle so players can reassign without a deadlock.

Claude-Session: https://claude.ai/code/session_01RvPbu4RhykvbUgyqpE1mJK