### PR TITLE
feat(UpdatePrompt): full-width sticky top bar with pulsing reload button

### DIFF
--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,22 +1,23 @@
-import React from "react";
+import React from 'react';
+import { RefreshCw } from 'lucide-react';
 
 type UpdatePromptProps = {
   show: boolean;
   onRefresh: () => void;
 };
 
-export const UpdatePrompt: React.FC<UpdatePromptProps> = ({
-  show,
-  onRefresh,
-}) => {
+export const UpdatePrompt: React.FC<UpdatePromptProps> = ({ show, onRefresh }) => {
   if (!show) return null;
 
   return (
-    <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 z-50 bg-blue-700 text-white px-6 py-3 rounded shadow-lg flex items-center gap-4">
-      <span>New version available.</span>
+    <div className="fixed top-0 left-0 right-0 z-[9999] flex items-center justify-between gap-3 bg-amber-500 px-4 py-3 shadow-lg shadow-amber-500/40">
+      <div className="flex items-center gap-2 text-white font-semibold text-sm">
+        <RefreshCw size={16} className="flex-shrink-0 animate-spin" style={{ animationDuration: '2s' }} />
+        <span>New version available — update for latest changes</span>
+      </div>
       <button
-        className="ml-4 px-3 py-1 rounded bg-white text-blue-700 font-semibold"
         onClick={onRefresh}
+        className="flex-shrink-0 rounded-lg bg-white px-4 py-1.5 text-sm font-black text-amber-600 shadow-md animate-pulse"
       >
         Reload
       </button>


### PR DESCRIPTION
Replaces the subtle bottom-center pill with a full-width amber banner pinned to the top of the screen. Spinning refresh icon + pulsing Reload button make it impossible to miss on any scroll position.

Claude-Session: https://claude.ai/code/session_01RvPbu4RhykvbUgyqpE1mJK