### PR TITLE
fix: fall back to fullTime for penalty winner when score.winner is null

### DIFF
--- a/netlify/functions/autoFetchWcResult.js
+++ b/netlify/functions/autoFetchWcResult.js
@@ -107,7 +107,16 @@ async function fetchFromFootballData(match) {
   let penaltyWinner = null;
   if (isPenaltyShootout) {
     const w = matchData.score?.winner;
-    penaltyWinner = w === 'HOME_TEAM' ? 'home' : w === 'AWAY_TEAM' ? 'away' : null;
+    if (w === 'HOME_TEAM') penaltyWinner = 'home';
+    else if (w === 'AWAY_TEAM') penaltyWinner = 'away';
+    else {
+      // winner field null — fall back to fullTime which contains penalty aggregate
+      const ftHome = matchData.score?.fullTime?.home;
+      const ftAway = matchData.score?.fullTime?.away;
+      if (ftHome != null && ftAway != null && ftHome !== ftAway) {
+        penaltyWinner = ftHome > ftAway ? 'home' : 'away';
+      }
+    }
   }
 
   return { homeGoals, awayGoals, penaltyWinner };

--- a/netlify/functions/fetchWcResult.js
+++ b/netlify/functions/fetchWcResult.js
@@ -123,12 +123,19 @@ async function fetchFromFootballData(match) {
     return { notFinished: true, status };
   }
 
-  // For penalty-decided matches derive the winner from score.winner — more
-  // reliable than comparing penalty goal counts.
   let penaltyWinner = null;
   if (isPenaltyShootout) {
     const w = matchData.score?.winner;
-    penaltyWinner = w === 'HOME_TEAM' ? 'home' : w === 'AWAY_TEAM' ? 'away' : null;
+    if (w === 'HOME_TEAM') penaltyWinner = 'home';
+    else if (w === 'AWAY_TEAM') penaltyWinner = 'away';
+    else {
+      // winner field null — fall back to fullTime which contains penalty aggregate
+      const ftHome = matchData.score?.fullTime?.home;
+      const ftAway = matchData.score?.fullTime?.away;
+      if (ftHome != null && ftAway != null && ftHome !== ftAway) {
+        penaltyWinner = ftHome > ftAway ? 'home' : 'away';
+      }
+    }
   }
 
   return { homeGoals, awayGoals, penaltyWinner, source: 'football-data' };


### PR DESCRIPTION
football-data.org sometimes returns score.winner as null for PENALTY_SHOOTOUT matches despite the result being available in score.fullTime. Fall back to comparing fullTime home vs away to correctly determine who advanced on penalties.

Claude-Session: https://claude.ai/code/session_01RvPbu4RhykvbUgyqpE1mJK